### PR TITLE
Added song info in reply to original tweet

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,16 @@ STREAM.on('nowPlaying', (track) => {
           
           let lyricSnippet = pickSnippetFromGroupedLyrics(response.lyrics);
           let tweet = formatStringForTwitter(lyricSnippet);
-          TWITTER.sendTweet(tweet, MODE);
+          
+          TWITTER.sendTweet(tweet, MODE)
+            .then((response) => {
+            
+              console.log(response);
+              let reply = [response.handle, track.artist['#text'], track.name];
+              let formattedReply = formatStringForTwitter(reply);
+              
+              TWITTER.replyToTweet(response.id, formattedReply, MODE);
+            })
         })
     })
      .catch((err) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MyCurrentLyrics",
-  "version": "0.0.100",
+  "version": "0.0.110",
   "description": "Tweets lyrics from the song you're currently listening to",
   "main": "index.js",
   "engines": {

--- a/twitterHandler.js
+++ b/twitterHandler.js
@@ -17,12 +17,33 @@ TWITTERHANDLER.sendTweet = (lyrics, mode) => {
     return null;
   }
   else if (mode === 'prod') {
-    CLIENT.post('statuses/update', {status: lyrics},  (err) => {
-      if (err) console.log(err);
-    });
+    return new Promise((resolve, reject) => {
+      
+      CLIENT.post('statuses/update', {status: lyrics},  (err, response) => {
+        if (err) {
+          console.log(err);
+          reject(err);
+        }
+        resolve({
+          id: response.id_str,
+          handle: `@${response.user.screen_name}`,
+        });
+      });
+    })
+    
   }
 };
 
+TWITTERHANDLER.replyToTweet = (inReplyTo, tweet, mode) => {
+  if (mode === 'test') {
+    return null;
+  }
+  else if (mode === 'prod') {
+    CLIENT.post('statuses/update', {status: tweet, in_reply_to_status_id: inReplyTo},  (err) => {
+      if (err) console.log(err);
+    });
+  }
+}
 
 
 module.exports = TWITTERHANDLER;


### PR DESCRIPTION
Implements the artist/song credit as a reply to the original tweet with lyrics.

- Changes the `TWITTERHANDLER.sendTweet` function, so it returns a promise. Resolves the Tweet ID and the handle posted under.
- Added `TWITTERHANDLER.replyToTweet`, which takes the person to reply to (ideally the handle resolved in `sendTweet`), the message to reply with, and the mode the script is running in.
- After `sendTweet` is called, the response is passed to `replyToTweet` with the required parameters.